### PR TITLE
Add crm.objects.quotes.read scope

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -208,6 +208,7 @@
       "crm.objects.owners.read",
       "crm.schemas.quotes.read",
       "crm.objects.quotes.write",
+      "crm.objects.quotes.read",
       "crm.objects.companies.read",
       "crm.objects.contacts.write",
       "settings.users.write",


### PR DESCRIPTION
This was the one scope missing from the manifest that prevented us from connecting to Hubspot using sesam-py.